### PR TITLE
fix: added hashcode guava google in geolocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     // compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'com.squareup.okhttp3:okhttp:3.12.0'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
+    implementation 'com.google.guava:guava:28.1-jre'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/src/main/java/com/osrm/client/GeoLocation.java
+++ b/src/main/java/com/osrm/client/GeoLocation.java
@@ -1,5 +1,7 @@
 package com.osrm.client;
 
+import com.google.common.base.Objects;
+
 public class GeoLocation {
     private final Double latitude;
     private final Double longitude;
@@ -23,7 +25,7 @@ public class GeoLocation {
 
     @Override
     public int hashCode() {
-        return latitude.hashCode() + longitude.hashCode();
+        return Objects.hashCode(this.getLatitude(), this.getLongitude());
     }
 
     @Override


### PR DESCRIPTION
## Overview

### What is the feature?
When obtaining a time matrix in the optimization, an array of unique positions is generated, but a hashcode collision between 2 positions was found, which generates an error when trying to reconstruct the matrix.

### What is the solution?
The google guava library was added to have a better distributed hash and avoid collision

### What areas of the site does it impact?
It should only have an impact on the optimization versions that point to this new version.



